### PR TITLE
Fix not work after update to HA core 2022.7.0

### DIFF
--- a/custom_components/line_bot/notify.py
+++ b/custom_components/line_bot/notify.py
@@ -70,8 +70,11 @@ class LineNotificationService(BaseNotificationService):
             _LOGGER.error("Missing client_id or access_token to send message")
             return
 
-        headers = {AUTHORIZATION: "Bearer " + access_token,
-                   'Content-type': 'application/json'}
+        headers = {
+            "Authorization": "Bearer {}".format(access_token),
+            "Content-type": "application/json"
+        }
+
         try:
             payload = json.loads(message.encode('utf-8'))
         except ValueError:


### PR DESCRIPTION
HA core 2022.7.0 is upgraded to Python 3.10. The header of the request can not use constants.